### PR TITLE
UI updates based on design feedback

### DIFF
--- a/public/components/text_to_dashboard/input_panel.tsx
+++ b/public/components/text_to_dashboard/input_panel.tsx
@@ -286,8 +286,11 @@ export const InputPanel = (props: Props) => {
     <EuiFlyout onClose={props.onClose}>
       <EuiFlyoutHeader hasBorder>
         <EuiTitle size="m">
-          <h2>Suggested analytics</h2>
+          <h2>Available insights</h2>
         </EuiTitle>
+        <div style={{ marginTop: '5px' }}>
+          Select an insight metric from the lists below to add to a dashboard.
+        </div>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
         {panelStatus === 'INSIGHTS_LOADING' && (
@@ -317,14 +320,24 @@ export const InputPanel = (props: Props) => {
       <EuiFlyoutFooter>
         <EuiFlexGroup justifyContent="spaceBetween">
           <EuiFlexItem grow={false}>
-            <EuiButton
-              fill
-              onClick={onGenerate}
-              isLoading={panelStatus === 'DASHBOARDS_CREATING'}
-              isDisabled={selectedInsights.length === 0}
-            >
-              Generate dashboard
-            </EuiButton>
+            {selectedInsights.length === 0 ? (
+              <EuiButton
+                fill
+                onClick={onGenerate}
+                isLoading={panelStatus === 'DASHBOARDS_CREATING'}
+                isDisabled
+              >
+                Generate dashboard
+              </EuiButton>
+            ) : (
+              <EuiButton
+                fill
+                onClick={onGenerate}
+                isLoading={panelStatus === 'DASHBOARDS_CREATING'}
+              >
+                Generate {selectedInsights.length} insight(s) to dashboard
+              </EuiButton>
+            )}
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlyoutFooter>

--- a/public/ui_actions.tsx
+++ b/public/ui_actions.tsx
@@ -29,7 +29,7 @@ export function registerGenerateDashboardUIAction(services: Services) {
   services.uiActions.addTriggerAction(AI_ASSISTANT_QUERY_EDITOR_TRIGGER, {
     id: 'assistant_generate_dashboard_action',
     order: 10,
-    getDisplayName: () => 'Data insights',
+    getDisplayName: () => 'Generate insights',
     getIconType: () => 'dashboard' as const,
     // T2Viz is only compatible with data sources that have certain agents configured
     isCompatible: async (context) => {


### PR DESCRIPTION
This PR makes the following UI updates:

0. Rename the button text to Generate insights 
1. Change the side panel title to Available insights 
2. Add help text under the title, "Select an insight metric from the lists below to add to a dashboard."
3. As the user add's insight metrics, the blue primary button on the side panel can say, "Generate # insight(s) to dashboard", where "#" is the number of insights a user selects.
